### PR TITLE
opencv-python and numpy version should be compatible

### DIFF
--- a/python-imager/Dockerfile
+++ b/python-imager/Dockerfile
@@ -16,7 +16,9 @@ FROM quay.io/antaris-inc/satos-payload-app-python:stable
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt install -y python3-opencv
-RUN python3 -m pip install opencv-python
+RUN python3 -m pip install --upgrade pip
+RUN python3 -m pip install --upgrade opencv-python
+RUN python3 -m pip install --upgrade numpy
 
 ADD samples /opt/antaris/app/samples
 ADD src /opt/antaris/app/src


### PR DESCRIPTION
Removed following error :
  File "/opt/antaris/app/src/app.py", line 27, in <module>
    import imager
  File "/opt/antaris/app/src/imager.py", line 19, in <module>
    import cv2
  File "/usr/local/lib/python3.10/dist-packages/cv2/__init__.py", line 181, in <module>
    bootstrap()
  File "/usr/local/lib/python3.10/dist-packages/cv2/__init__.py", line 175, in bootstrap
    if __load_extra_py_code_for_module("cv2", submodule, DEBUG):
  File "/usr/local/lib/python3.10/dist-packages/cv2/__init__.py", line 28, in __load_extra_py_code_for_module
    py_module = importlib.import_module(module_name)
  File "/usr/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "/usr/local/lib/python3.10/dist-packages/cv2/typing/__init__.py", line 69, in <module>
    NumPyArrayGeneric = numpy.ndarray[typing.Any, numpy.dtype[numpy.generic]]
TypeError: 'numpy._DTypeMeta' object is not subscriptable